### PR TITLE
READ処理の実装

### DIFF
--- a/src/main/java/com/example/deskworkoutservice/Deskworkout.java
+++ b/src/main/java/com/example/deskworkoutservice/Deskworkout.java
@@ -1,0 +1,48 @@
+package com.example.deskworkoutservice;
+
+public class Deskworkout {
+    private final int id;
+
+    private final String name;
+
+    private final String howto;
+
+    private final int repetition;
+
+    private final String bodyparts;
+
+    private final String difficulty;
+
+    public Deskworkout(int id, String name, String howto, int repetition, String bodyparts, String difficulty) {
+        this.id = id;
+        this.name = name;
+        this.howto = howto;
+        this.repetition = repetition;
+        this.bodyparts = bodyparts;
+        this.difficulty = difficulty;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getHowto() {
+        return howto;
+    }
+
+    public int getRepetition() {
+        return repetition;
+    }
+
+    public String getBodyparts() {
+        return bodyparts;
+    }
+
+    public String getDifficulty() {
+        return difficulty;
+    }
+}

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutController.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutController.java
@@ -1,0 +1,46 @@
+package com.example.deskworkoutservice;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+public class DeskworkoutController {
+
+    private final DeskworkoutService deskworkoutService;
+
+    public DeskworkoutController(DeskworkoutService deskworkoutService) {
+        this.deskworkoutService = deskworkoutService;
+    }
+
+    @GetMapping("/deskworkouts")
+    public List<Deskworkout> findByBodyparts(@RequestParam(value = "bodyparts", required = false) String bodyparts) {
+        return deskworkoutService.findByBodypartsStartingWith(bodyparts);
+    }
+
+    @GetMapping("/deskworkouts/{id}")
+    public Deskworkout findByInformation(@PathVariable("id") int id) {
+        return deskworkoutService.findById(id);
+    }
+
+    @ExceptionHandler(value = DeskworkoutNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleDeskworkoutNotFoundException(
+            DeskworkoutNotFoundException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutMapper.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutMapper.java
@@ -1,0 +1,20 @@
+package com.example.deskworkoutservice;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface DeskworkoutMapper {
+
+    @Select("SELECT * FROM deskworkouts")
+    List<Deskworkout> findAll();
+
+    @Select("SELECT * FROM deskworkouts WHERE bodyparts LIKE CONCAT (#{bodyparts}, '%' )")
+    List<Deskworkout> findByBodypartsStartingWith(String bodyparts);
+
+    @Select("SELECT * FROM deskworkouts WHERE id = #{id}")
+    Optional<Deskworkout> findById(int id);
+}

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutNotFoundException.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.deskworkoutservice;
+
+public class DeskworkoutNotFoundException extends RuntimeException {
+    public DeskworkoutNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
@@ -1,0 +1,32 @@
+package com.example.deskworkoutservice;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DeskworkoutService {
+    private final DeskworkoutMapper deskworkoutMapper;
+
+    public DeskworkoutService(DeskworkoutMapper deskworkoutMapper) {
+        this.deskworkoutMapper = deskworkoutMapper;
+    }
+
+    public List<Deskworkout> findByBodypartsStartingWith(String bodyparts) {
+        if (bodyparts != null && !bodyparts.isEmpty()) {
+            return deskworkoutMapper.findByBodypartsStartingWith(bodyparts);
+        } else {
+            return deskworkoutMapper.findAll();
+        }
+    }
+
+    public Deskworkout findById(int id) {
+        Optional<Deskworkout> deskworkout = this.deskworkoutMapper.findById(id);
+        if (deskworkout.isPresent()) {
+            return deskworkout.get();
+        } else {
+            throw new DeskworkoutNotFoundException("Workout with id:" + id + " not found");
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=deskworkoutservice
+spring.datasource.url=jdbc:mysql://localhost:3307/deskworkout_database
+spring.datasource.username=user
+spring.datasource.password=password


### PR DESCRIPTION
# 最終課題
デスクでできる筋トレメニューの取得/登録/更新/削除ができるアプリケーションを実装します。

# READ処理の概要

最終課題(旧カリキュラム)のREAD処理を実装しました。

実装内容は下記の通りです。
- レコードの全件取得する
- クエリ文字列を用いて特定のbodypartsを記入すると該当するレコードを取得する (該当するレコードがない場合は空文字を返す)
- ID検索を用いて該当するレコードを取得する (IDが存在しない場合は404を返す)

# 動作確認

## 全件取得

下記確認済みです。
- ステータスコードが200であること
-  JSON形式であること
- 全5件のレコードを取得

![全件取得1](https://github.com/affy03/deskworkoutservice/assets/159910151/c551db1b-6d32-4a91-aa55-3b67afda9580)
▽続きです
![全件取得2](https://github.com/affy03/deskworkoutservice/assets/159910151/43e0181a-d2e6-479a-977b-9d9577f77e1e)


## クエリ検索

下記確認済みです。
- ステータスコードが200であること
-  JSON形式であること
- bodyparts?=肩と検索→該当するレコードを取得

![クエリ検索](https://github.com/affy03/deskworkoutservice/assets/159910151/ee6f2d17-2ea7-4a72-b0bf-c7a1b0d0a219)
- bodyparts?=腕と検索→該当するレコードがないので空文字を返す
![クエリ検索(該当するレコードなし)](https://github.com/affy03/deskworkoutservice/assets/159910151/0ad88806-ce76-4407-a85d-53c140d726be)



## ID検索

下記確認済みです。
- ステータスコードが200であること
-  JSON形式であること
- /1 で検索→該当するレコードを取得

![id検索](https://github.com/affy03/deskworkoutservice/assets/159910151/6cfa8752-29fc-4c6b-a485-6939a7ce6e52)
- /100 で検索→該当するレコードがないので404を返す
![id検索(例外)](https://github.com/affy03/deskworkoutservice/assets/159910151/2d7d21d0-acc7-4577-a7d2-7dddabda75f8)
