### PR TITLE
DELETE処理の実装

### DIFF
--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutController.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutController.java
@@ -3,6 +3,7 @@ package com.example.deskworkoutservice;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -74,6 +75,13 @@ public class DeskworkoutController {
                 deskworkoutRequest.getBodyparts(),
                 deskworkoutRequest.getDifficulty());
         DeskworkoutResponse body = new DeskworkoutResponse("deskworkout updated");
+        return ResponseEntity.ok(body);
+    }
+
+    @DeleteMapping("/deskworkouts/{id}")
+    public ResponseEntity<DeskworkoutResponse> delete(@PathVariable int id) {
+        deskworkoutService.delete(id);
+        DeskworkoutResponse body = new DeskworkoutResponse("deskworkout deleted");
         return ResponseEntity.ok(body);
     }
 }

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutMapper.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutMapper.java
@@ -1,5 +1,6 @@
 package com.example.deskworkoutservice;
 
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
@@ -27,4 +28,7 @@ public interface DeskworkoutMapper {
 
     @Update("UPDATE deskworkouts SET name=#{name}, howto=#{howto}, repetition=#{repetition}, bodyparts=#{bodyparts}, difficulty=#{difficulty} WHERE id = #{id}")
     void update(Deskworkout deskworkout);
+
+    @Delete("DELETE FROM deskworkouts WHERE id = #{id}")
+    void delete(int id);
 }

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
@@ -38,7 +38,7 @@ public class DeskworkoutService {
         return deskworkout;
     }
 
-    public Deskworkout update(Integer id, String name, String howto, Integer repetition, String bodyparts, String difficulty) {
+    public void update(Integer id, String name, String howto, Integer repetition, String bodyparts, String difficulty) {
         Deskworkout deskworkout = deskworkoutMapper.findById(id)
                 .orElseThrow(() -> new DeskworkoutNotFoundException("Workout with id:" + id + " not found"));
 
@@ -49,6 +49,11 @@ public class DeskworkoutService {
         deskworkout.setDifficulty(difficulty);
 
         deskworkoutMapper.update(deskworkout);
-        return deskworkout;
+    }
+
+    public void delete(int id) {
+        deskworkoutMapper.findById(id)
+                .orElseThrow(() -> new DeskworkoutNotFoundException("Workout with id:" + id + " not found"));
+        deskworkoutMapper.delete(id);
     }
 }


### PR DESCRIPTION
# 最終課題

デスクでできる筋トレメニューの取得/登録/更新/削除ができるアプリケーションを実装します。

## DELETE処理

今回はDELETE（削除）処理の実装を行いました。
また削除するデータが存在しない場合の例外ハンドリングを実装しました。

下記確認済みです。

- json形式かつステータスコードが200であること
- 期待通りのレスポンスボディが表示されていること
![削除postman](https://github.com/affy03/deskworkoutservice/assets/159910151/64c110d2-f7eb-41f0-814a-ff090f9b574f)

- テーブルのレコードが削除されていること

削除前▽
![削除前DB](https://github.com/affy03/deskworkoutservice/assets/159910151/10992482-69d7-4ee1-b3bc-e574a4e489d6)
削除後▽
![削除後DB](https://github.com/affy03/deskworkoutservice/assets/159910151/be7fecab-81aa-4c42-9115-44aba05260d7)

- 存在しないID 9 で削除→404エラー
![削除例外postman](https://github.com/affy03/deskworkoutservice/assets/159910151/0bee3ac2-d85d-4f1e-82bf-814bf9e78137)
