### PR TITLE
バリデーションの追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.hibernate:hibernate-core:5.6.4.Final'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutController.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutController.java
@@ -1,10 +1,8 @@
 package com.example.deskworkoutservice;
 
-import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.http.HttpStatus;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,9 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 public class DeskworkoutController {
@@ -38,21 +34,8 @@ public class DeskworkoutController {
         return deskworkoutService.findById(id);
     }
 
-    @ExceptionHandler(value = DeskworkoutNotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleDeskworkoutNotFoundException(
-            DeskworkoutNotFoundException e, HttpServletRequest request) {
-        Map<String, String> body = Map.of(
-                "timestamp", ZonedDateTime.now().toString(),
-                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
-                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
-                "message", e.getMessage(),
-                "path", request.getRequestURI());
-        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
-    }
-
-
     @PostMapping("/deskworkouts")
-    public ResponseEntity<DeskworkoutResponse> insert(@RequestBody DeskworkoutRequest deskworkoutRequest, UriComponentsBuilder uriBuilder) {
+    public ResponseEntity<DeskworkoutResponse> insert(@RequestBody @Valid DeskworkoutRequest deskworkoutRequest, UriComponentsBuilder uriBuilder) {
         Deskworkout deskworkout = deskworkoutService.insert(
                 deskworkoutRequest.getName(),
                 deskworkoutRequest.getHowto(),
@@ -66,7 +49,7 @@ public class DeskworkoutController {
     }
 
     @PatchMapping("/deskworkouts/{id}")
-    public ResponseEntity<DeskworkoutResponse> update(@PathVariable("id") int id, @RequestBody DeskworkoutRequest deskworkoutRequest) {
+    public ResponseEntity<DeskworkoutResponse> update(@PathVariable("id") int id, @RequestBody @Valid DeskworkoutRequest deskworkoutRequest) {
         deskworkoutService.update(
                 id,
                 deskworkoutRequest.getName(),

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutExceptionHandler.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.example.deskworkoutservice;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class DeskworkoutExceptionHandler {
+
+    @ExceptionHandler(value = DeskworkoutNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleDeskworkoutNotFoundException(
+            DeskworkoutNotFoundException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutRequest.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutRequest.java
@@ -9,11 +9,11 @@ import jakarta.validation.constraints.Size;
 public class DeskworkoutRequest {
 
     @NotBlank(message = "空白は許可されていません")
-    @Size(max = 20, message = "名前は20文字以内で入力してください")
+    @Size(max = 20, message = "名前は{max}文字以内で入力してください")
     private String name;
 
     @NotBlank(message = "空白は許可されていません")
-    @Size(max = 100, message = "動作説明は100文字以内で入力してください")
+    @Size(max = 100, message = "動作説明は{max}文字以内で入力してください")
     private String howto;
 
     @NotNull(message = "空白は許可されていません")
@@ -21,11 +21,11 @@ public class DeskworkoutRequest {
     private Integer repetition;
 
     @NotBlank(message = "空白は許可されていません")
-    @Size(max = 100, message = "部位は100文字以内で入力してください")
+    @Size(max = 100, message = "部位は{max}文字以内で入力してください")
     private String bodyparts;
 
     @NotBlank(message = "空白は許可されていません")
-    @Size(max = 20, message = "難易度は20文字以内で入力してください")
+    @Size(max = 20, message = "難易度は{max}文字以内で入力してください")
     private String difficulty;
 
     public DeskworkoutRequest(String name, String howto, int repetition, String bodyparts, String difficulty) {

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutRequest.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutRequest.java
@@ -1,16 +1,31 @@
 package com.example.deskworkoutservice;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
 //デスクワークアウト情報の登録 更新に使用
 public class DeskworkoutRequest {
 
+    @NotBlank(message = "空白は許可されていません")
+    @Size(max = 20, message = "名前は20文字以内で入力してください")
     private String name;
 
+    @NotBlank(message = "空白は許可されていません")
+    @Size(max = 100, message = "動作説明は100文字以内で入力してください")
     private String howto;
 
+    @NotNull(message = "空白は許可されていません")
+    @Positive(message = "レップ数は自然数で入力してください")
     private Integer repetition;
 
+    @NotBlank(message = "空白は許可されていません")
+    @Size(max = 100, message = "部位は100文字以内で入力してください")
     private String bodyparts;
 
+    @NotBlank(message = "空白は許可されていません")
+    @Size(max = 20, message = "難易度は20文字以内で入力してください")
     private String difficulty;
 
     public DeskworkoutRequest(String name, String howto, int repetition, String bodyparts, String difficulty) {


### PR DESCRIPTION
# 最終課題

デスクでできる筋トレメニューの取得/登録/更新/削除ができるアプリケーションを実装します。

## バリデーションの追加

今回はCRUD処理にバリデーションを追加しました。

## 動作確認
下記確認済みです。
- json形式かつ期待通りのレスポンスボディであること

- 正常な時→200 OKを返す
![正常](https://github.com/affy03/deskworkoutservice/assets/159910151/399652ad-e2b2-4062-ae87-d6bef0526ea8)

- Nullの時→400 Bad Requestを返す
![Not Null2](https://github.com/affy03/deskworkoutservice/assets/159910151/de5ede8d-226c-4182-88a4-dfa0a552ad3b)

- 空白の時→400 Bad Requestを返す
![Not Blank](https://github.com/affy03/deskworkoutservice/assets/159910151/b8d9c1f2-2ab1-40cc-90a3-110d90b00184)

- 空文字の時→400 Bad Requestを返す
![Not Empty](https://github.com/affy03/deskworkoutservice/assets/159910151/4daae6f2-e63f-4260-9f99-99a8fe616e3a)

- 文字数制限を超えた時→400 Bad Requestを返す
![文字数制限](https://github.com/affy03/deskworkoutservice/assets/159910151/eb94e950-e845-4d00-b7b1-0fa087224503)
