### PR TITLE
READ処理の単体テスト実装

### DIFF
--- a/src/main/java/com/example/deskworkoutservice/Deskworkout.java
+++ b/src/main/java/com/example/deskworkoutservice/Deskworkout.java
@@ -6,6 +6,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.util.Objects;
 
 @Entity
 @Table(name = "deskworkouts")
@@ -97,5 +98,34 @@ public class Deskworkout {
 
     public void setDifficulty(String difficulty) {
         this.difficulty = difficulty;
+    }
+
+    //equals メソッドのオーバーライド
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Deskworkout that = (Deskworkout) o;
+        return repetition == that.repetition &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(howto, that.howto) &&
+                Objects.equals(bodyparts, that.bodyparts) &&
+                Objects.equals(difficulty, that.difficulty);
+    }
+
+    // hashCode メソッドのオーバーライド
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, howto, repetition, bodyparts, difficulty);
+    }
+
+    @Override
+    public String toString() {
+        return "{\"id\":" + id +
+                ",\"name\":\"" + name + "\"" +
+                ",\"howto\":\"" + howto + "\"" +
+                ",\"repetition\":" + repetition +
+                ",\"bodyparts\":\"" + bodyparts + "\"" +
+                ",\"difficulty\":\"" + difficulty + "\"}";
     }
 }

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
@@ -14,6 +14,10 @@ public class DeskworkoutService {
         this.deskworkoutMapper = deskworkoutMapper;
     }
 
+    public List<Deskworkout> findAll() {
+        return deskworkoutMapper.findAll();
+    }
+
     public List<Deskworkout> findByBodypartsStartingWith(String bodyparts) {
         if (bodyparts != null && !bodyparts.isEmpty()) {
             return deskworkoutMapper.findByBodypartsStartingWith(bodyparts);

--- a/src/test/java/com/example/deskworkoutservice/DeskworkoutServiceTest.java
+++ b/src/test/java/com/example/deskworkoutservice/DeskworkoutServiceTest.java
@@ -1,0 +1,60 @@
+package com.example.deskworkoutservice;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DeskworkoutServiceTest {
+    //@InjectMockでDeskworkoutServiceを自動的にインスタンス化し、モックオブジェクトのdeskworkoutMapperを注入する
+    @InjectMocks
+    private DeskworkoutService deskworkoutService;//インスタンス変数
+
+    @Mock
+    private DeskworkoutMapper deskworkoutMapper;//インスタンス変数
+
+    @Test
+    public void null又は空のクエリ文字列を渡したときに全てのレコードを取得できること() {
+        List<Deskworkout> deskworkouts = List.of(
+                new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級"),
+                new Deskworkout(2, "バックエクステンション", "お尻を背もたれに付けたまま、デコルテを机に近づける", 10, "背中", "中級"),
+                new Deskworkout(3, "ショルダーダウン", "肘で背もたれを押したまま、肩を引き下げる", 1, "肩", "初級"),
+                new Deskworkout(4, "ニーエクステンション", "内ももをくっ付けたまま、膝を伸ばす", 10, "脚", "初級"),
+                new Deskworkout(5, "スクワット", "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる", 10, "お尻", "上級")
+        );
+        doReturn(deskworkouts).when(deskworkoutMapper).findAll();
+        List<Deskworkout> actualEmptyString = deskworkoutService.findByBodypartsStartingWith("");
+        List<Deskworkout> actualNull = deskworkoutService.findByBodypartsStartingWith(null);
+        assertThat(actualEmptyString).isEqualTo(deskworkouts);
+        assertThat(actualNull).isEqualTo(deskworkouts);
+        verify(deskworkoutMapper, times(2)).findAll();
+    }
+
+    @Test
+    public void 存在するIDを指定したときに該当するレコードを取得できること() throws Exception {
+        doReturn(Optional.of(new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級")))
+                .when(deskworkoutMapper).findById(1);
+        Deskworkout actual = deskworkoutService.findById(1);
+        assertThat(actual).isEqualTo(new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級"));
+        verify(deskworkoutMapper).findById(1);
+    }
+
+    @Test
+    public void 存在しないIDを指定したときに例外が発生すること() {
+        doReturn(Optional.empty()).when(deskworkoutMapper).findById(100);
+        assertThatThrownBy(() -> deskworkoutService.findById(100))
+                .isInstanceOf(DeskworkoutNotFoundException.class);
+        verify(deskworkoutMapper).findById(100);
+    }
+}


### PR DESCRIPTION
# 最終課題

「デスクでできる筋トレメニュー」を管理するアプリケーションを、CRUD処理を用いて開発します。

## READ処理の単体テスト

今回はJunitを用いて、READ処理のServiceクラスに対する単体テストを実装しました。

## 検証内容

下記確認済みです。

- null又は空のクエリ文字列を渡したときに全てのレコードを取得できること
- 存在するIDを指定したときに該当するレコードを取得できること
- 存在しないIDを指定したときに例外が発生すること

## 検証結果
テスト成功しています。
![スクリーンショット 2024-07-26 171529](https://github.com/user-attachments/assets/37bb2e83-01b6-42eb-9553-624ba8a7f5ee)

