### PR TITLE
Read処理の単体テスト実装

### DIFF
--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -3,15 +3,15 @@ DROP TABLE IF EXISTS deskworkouts;
 CREATE TABLE deskworkouts (
   id int unsigned AUTO_INCREMENT,
   name VARCHAR(20) NOT NULL,
-  howto VARCHAR(200) NOT NULL DEFAULT '未設定',
+  howTo VARCHAR(200) NOT NULL DEFAULT '未設定',
   repetition INT NOT NULL DEFAULT 0,
-  bodyparts VARCHAR(100)  NOT NULL DEFAULT '未設定',
+  bodyParts VARCHAR(100)  NOT NULL DEFAULT '未設定',
   difficulty VARCHAR(20)  NOT NULL DEFAULT '未設定',
   PRIMARY KEY(id)
 );
 
-INSERT INTO deskworkouts (name, howto, repetition, bodyparts, difficulty ) VALUES ("シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級");
-INSERT INTO deskworkouts (name, howto, repetition, bodyparts, difficulty) VALUES  ("バックエクステンション", "お尻を背もたれに付けたまま、デコルテを机に近づける", 10, "背中", "中級");
-INSERT INTO deskworkouts (name, howto, repetition, bodyparts, difficulty ) VALUES ("ショルダーダウン", "肘で背もたれを押したまま、肩を引き下げる", 1, "肩", "初級");
-INSERT INTO deskworkouts (name, howto, repetition, bodyparts, difficulty) VALUES  ("ニーエクステンション", "内ももをくっ付けたまま、膝を伸ばす", 10, "脚", "初級");
-INSERT INTO deskworkouts (name, howto, repetition, bodyparts, difficulty ) VALUES ("スクワット", "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる", 10, "お尻", "上級");
+INSERT INTO deskworkouts (name, howTo, repetition, bodyParts, difficulty ) VALUES ("シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級");
+INSERT INTO deskworkouts (name, howTo, repetition, bodyParts, difficulty) VALUES  ("バックエクステンション", "お尻を背もたれに付けたまま、デコルテを机に近づける", 10, "背中", "中級");
+INSERT INTO deskworkouts (name, howTo, repetition, bodyParts, difficulty ) VALUES ("ショルダーダウン", "肘で背もたれを押したまま、肩を引き下げる", 1, "肩", "初級");
+INSERT INTO deskworkouts (name, howTo, repetition, bodyParts, difficulty) VALUES  ("ニーエクステンション", "内ももをくっ付けたまま、膝を伸ばす", 10, "脚", "初級");
+INSERT INTO deskworkouts (name, howTo, repetition, bodyParts, difficulty ) VALUES ("スクワット", "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる", 10, "お尻", "上級");

--- a/src/main/java/com/example/deskworkoutservice/Deskworkout.java
+++ b/src/main/java/com/example/deskworkoutservice/Deskworkout.java
@@ -6,6 +6,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.util.Objects;
 
 @Entity
 @Table(name = "deskworkouts")
@@ -97,5 +98,34 @@ public class Deskworkout {
 
     public void setDifficulty(String difficulty) {
         this.difficulty = difficulty;
+    }
+
+    //equals メソッドのオーバーライド
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Deskworkout that = (Deskworkout) o;
+        return repetition == that.repetition &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(howto, that.howto) &&
+                Objects.equals(bodyparts, that.bodyparts) &&
+                Objects.equals(difficulty, that.difficulty);
+    }
+
+    // hashCode メソッドのオーバーライド
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, howto, repetition, bodyparts, difficulty);
+    }
+
+    @Override
+    public String toString() {
+        return "{\"id\":" + id +
+                ",\"name\":\"" + name + "\"" +
+                ",\"howto\":\"" + howto + "\"" +
+                ",\"repetition\":" + repetition +
+                ",\"bodyparts\":\"" + bodyparts + "\"" +
+                ",\"difficulty\":\"" + difficulty + "\"}";
     }
 }

--- a/src/main/java/com/example/deskworkoutservice/Deskworkout.java
+++ b/src/main/java/com/example/deskworkoutservice/Deskworkout.java
@@ -19,32 +19,32 @@ public class Deskworkout {
     private String name;
 
     @Column(length = 200, nullable = false, columnDefinition = "VARCHAR(200) DEFAULT '未設定'")
-    private String howto;
+    private String howTo;
 
     @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
     private Integer repetition;
 
     @Column(length = 100, nullable = false, columnDefinition = "VARCHAR(100) DEFAULT '未設定'")
-    private String bodyparts;
+    private String bodyParts;
 
     @Column(length = 20, nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '未設定'")
     private String difficulty;
 
-    public Deskworkout(int id, String name, String howto, int repetition, String bodyparts, String difficulty) {
+    public Deskworkout(int id, String name, String howTo, int repetition, String bodyParts, String difficulty) {
         this.id = id;
         this.name = name;
-        this.howto = howto;
+        this.howTo = howTo;
         this.repetition = repetition;
-        this.bodyparts = bodyparts;
+        this.bodyParts = bodyParts;
         this.difficulty = difficulty;
     }
 
-    public Deskworkout(String name, String howto, int repetition, String bodyparts, String difficulty) {
+    public Deskworkout(String name, String howTo, int repetition, String bodyParts, String difficulty) {
         // id は INSERT文発行時に MySQLによって自動採番した値が補完されるので null を設定
         this.name = name;
-        this.howto = howto;
+        this.howTo = howTo;
         this.repetition = repetition;
-        this.bodyparts = bodyparts;
+        this.bodyParts = bodyParts;
         this.difficulty = difficulty;
     }
 
@@ -61,15 +61,15 @@ public class Deskworkout {
     }
 
     public String getHowto() {
-        return howto;
+        return howTo;
     }
 
     public int getRepetition() {
         return repetition;
     }
 
-    public String getBodyparts() {
-        return bodyparts;
+    public String getBodyParts() {
+        return bodyParts;
     }
 
     public String getDifficulty() {
@@ -84,16 +84,16 @@ public class Deskworkout {
         this.name = name;
     }
 
-    public void setHowto(String howto) {
-        this.howto = howto;
+    public void setHowto(String howTo) {
+        this.howTo = howTo;
     }
 
     public void setRepetition(int repetition) {
         this.repetition = repetition;
     }
 
-    public void setBodyparts(String bodyparts) {
-        this.bodyparts = bodyparts;
+    public void setBodyParts(String bodyParts) {
+        this.bodyParts = bodyParts;
     }
 
     public void setDifficulty(String difficulty) {
@@ -108,24 +108,24 @@ public class Deskworkout {
         Deskworkout that = (Deskworkout) o;
         return repetition == that.repetition &&
                 Objects.equals(name, that.name) &&
-                Objects.equals(howto, that.howto) &&
-                Objects.equals(bodyparts, that.bodyparts) &&
+                Objects.equals(howTo, that.howTo) &&
+                Objects.equals(bodyParts, that.bodyParts) &&
                 Objects.equals(difficulty, that.difficulty);
     }
 
     // hashCode メソッドのオーバーライド
     @Override
     public int hashCode() {
-        return Objects.hash(name, howto, repetition, bodyparts, difficulty);
+        return Objects.hash(name, howTo, repetition, bodyParts, difficulty);
     }
 
     @Override
     public String toString() {
         return "{\"id\":" + id +
                 ",\"name\":\"" + name + "\"" +
-                ",\"howto\":\"" + howto + "\"" +
+                ",\"howto\":\"" + howTo + "\"" +
                 ",\"repetition\":" + repetition +
-                ",\"bodyparts\":\"" + bodyparts + "\"" +
+                ",\"bodyparts\":\"" + bodyParts + "\"" +
                 ",\"difficulty\":\"" + difficulty + "\"}";
     }
 }

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutController.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutController.java
@@ -25,8 +25,8 @@ public class DeskworkoutController {
     }
 
     @GetMapping("/deskworkouts")
-    public List<Deskworkout> findByBodyparts(@RequestParam(value = "bodyparts", required = false) String bodyparts) {
-        return deskworkoutService.findByBodypartsStartingWith(bodyparts);
+    public List<Deskworkout> findByBodyparts(@RequestParam(value = "bodyParts", required = false) String bodyParts) {
+        return deskworkoutService.findByBodyPartsStartingWith(bodyParts);
     }
 
     @GetMapping("/deskworkouts/{id}")
@@ -38,9 +38,9 @@ public class DeskworkoutController {
     public ResponseEntity<DeskworkoutResponse> insert(@RequestBody @Valid DeskworkoutRequest deskworkoutRequest, UriComponentsBuilder uriBuilder) {
         Deskworkout deskworkout = deskworkoutService.insert(
                 deskworkoutRequest.getName(),
-                deskworkoutRequest.getHowto(),
+                deskworkoutRequest.getHowTo(),
                 deskworkoutRequest.getRepetition(),
-                deskworkoutRequest.getBodyparts(),
+                deskworkoutRequest.getBodyParts(),
                 deskworkoutRequest.getDifficulty()
         );
         URI location = uriBuilder.path("/deskworkouts/{id}").buildAndExpand(deskworkout.getId()).toUri();
@@ -53,9 +53,9 @@ public class DeskworkoutController {
         deskworkoutService.update(
                 id,
                 deskworkoutRequest.getName(),
-                deskworkoutRequest.getHowto(),
+                deskworkoutRequest.getHowTo(),
                 deskworkoutRequest.getRepetition(),
-                deskworkoutRequest.getBodyparts(),
+                deskworkoutRequest.getBodyParts(),
                 deskworkoutRequest.getDifficulty());
         DeskworkoutResponse body = new DeskworkoutResponse("deskworkout updated");
         return ResponseEntity.ok(body);

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutMapper.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutMapper.java
@@ -16,17 +16,17 @@ public interface DeskworkoutMapper {
     @Select("SELECT * FROM deskworkouts")
     List<Deskworkout> findAll();
 
-    @Select("SELECT * FROM deskworkouts WHERE bodyparts LIKE CONCAT (#{bodyparts}, '%' )")
-    List<Deskworkout> findByBodypartsStartingWith(String bodyparts);
+    @Select("SELECT * FROM deskworkouts WHERE bodyParts LIKE CONCAT (#{bodyParts}, '%' )")
+    List<Deskworkout> findByBodyPartsStartingWith(String bodyParts);
 
     @Select("SELECT * FROM deskworkouts WHERE id = #{id}")
     Optional<Deskworkout> findById(int id);
 
-    @Insert("INSERT INTO deskworkouts  (name, howto, repetition, bodyparts, difficulty ) VALUES (#{name},#{howto},#{repetition},#{bodyparts},#{difficulty})")
+    @Insert("INSERT INTO deskworkouts  (name, howTo, repetition, bodyParts, difficulty ) VALUES (#{name},#{howTo},#{repetition},#{bodyParts},#{difficulty})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void insert(Deskworkout deskworkout);
 
-    @Update("UPDATE deskworkouts SET name=#{name}, howto=#{howto}, repetition=#{repetition}, bodyparts=#{bodyparts}, difficulty=#{difficulty} WHERE id = #{id}")
+    @Update("UPDATE deskworkouts SET name=#{name}, howTo=#{howTo}, repetition=#{repetition}, bodyParts=#{bodyParts}, difficulty=#{difficulty} WHERE id = #{id}")
     void update(Deskworkout deskworkout);
 
     @Delete("DELETE FROM deskworkouts WHERE id = #{id}")

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutRequest.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutRequest.java
@@ -14,7 +14,7 @@ public class DeskworkoutRequest {
 
     @NotBlank(message = "空白は許可されていません")
     @Size(max = 100, message = "動作説明は{max}文字以内で入力してください")
-    private String howto;
+    private String howTo;
 
     @NotNull(message = "空白は許可されていません")
     @Positive(message = "レップ数は自然数で入力してください")
@@ -22,17 +22,17 @@ public class DeskworkoutRequest {
 
     @NotBlank(message = "空白は許可されていません")
     @Size(max = 100, message = "部位は{max}文字以内で入力してください")
-    private String bodyparts;
+    private String bodyParts;
 
     @NotBlank(message = "空白は許可されていません")
     @Size(max = 20, message = "難易度は{max}文字以内で入力してください")
     private String difficulty;
 
-    public DeskworkoutRequest(String name, String howto, int repetition, String bodyparts, String difficulty) {
+    public DeskworkoutRequest(String name, String howTo, int repetition, String bodyParts, String difficulty) {
         this.name = name;
-        this.howto = howto;
+        this.howTo = howTo;
         this.repetition = repetition;
-        this.bodyparts = bodyparts;
+        this.bodyParts = bodyParts;
         this.difficulty = difficulty;
     }
 
@@ -40,16 +40,16 @@ public class DeskworkoutRequest {
         return name;
     }
 
-    public String getHowto() {
-        return howto;
+    public String getHowTo() {
+        return howTo;
     }
 
     public int getRepetition() {
         return repetition;
     }
 
-    public String getBodyparts() {
-        return bodyparts;
+    public String getBodyParts() {
+        return bodyParts;
     }
 
     public String getDifficulty() {

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
@@ -14,10 +14,6 @@ public class DeskworkoutService {
         this.deskworkoutMapper = deskworkoutMapper;
     }
 
-    public List<Deskworkout> findAll() {
-        return deskworkoutMapper.findAll();
-    }
-
     public List<Deskworkout> findByBodypartsStartingWith(String bodyparts) {
         if (bodyparts != null && !bodyparts.isEmpty()) {
             return deskworkoutMapper.findByBodypartsStartingWith(bodyparts);

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
@@ -14,9 +14,9 @@ public class DeskworkoutService {
         this.deskworkoutMapper = deskworkoutMapper;
     }
 
-    public List<Deskworkout> findByBodypartsStartingWith(String bodyparts) {
-        if (bodyparts != null && !bodyparts.isEmpty()) {
-            return deskworkoutMapper.findByBodypartsStartingWith(bodyparts);
+    public List<Deskworkout> findByBodyPartsStartingWith(String bodyParts) {
+        if (bodyParts != null && !bodyParts.isEmpty()) {
+            return deskworkoutMapper.findByBodyPartsStartingWith(bodyParts);
         } else {
             return deskworkoutMapper.findAll();
         }
@@ -27,25 +27,25 @@ public class DeskworkoutService {
                 .orElseThrow(() -> new DeskworkoutNotFoundException("Workout with id:" + id + " not found"));
     }
 
-    public Deskworkout insert(String name, String howto, Integer repetition, String bodyparts, String difficulty) {
+    public Deskworkout insert(String name, String howTo, Integer repetition, String bodyParts, String difficulty) {
         Deskworkout deskworkout = new Deskworkout();
         deskworkout.setName(name);
-        deskworkout.setHowto(howto);
+        deskworkout.setHowto(howTo);
         deskworkout.setRepetition(repetition);
-        deskworkout.setBodyparts(bodyparts);
+        deskworkout.setBodyParts(bodyParts);
         deskworkout.setDifficulty(difficulty);
         deskworkoutMapper.insert(deskworkout);
         return deskworkout;
     }
 
-    public void update(Integer id, String name, String howto, Integer repetition, String bodyparts, String difficulty) {
+    public void update(Integer id, String name, String howTo, Integer repetition, String bodyParts, String difficulty) {
         Deskworkout deskworkout = deskworkoutMapper.findById(id)
                 .orElseThrow(() -> new DeskworkoutNotFoundException("Workout with id:" + id + " not found"));
 
         deskworkout.setName(name);
-        deskworkout.setHowto(howto);
+        deskworkout.setHowto(howTo);
         deskworkout.setRepetition(repetition);
-        deskworkout.setBodyparts(bodyparts);
+        deskworkout.setBodyParts(bodyParts);
         deskworkout.setDifficulty(difficulty);
 
         deskworkoutMapper.update(deskworkout);

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
@@ -14,6 +14,10 @@ public class DeskworkoutService {
         this.deskworkoutMapper = deskworkoutMapper;
     }
 
+    public List<Deskworkout> findAll() {
+        return deskworkoutMapper.findAll();
+    }
+
     public List<Deskworkout> findByBodypartsStartingWith(String bodyparts) {
         if (bodyparts != null && !bodyparts.isEmpty()) {
             return deskworkoutMapper.findByBodypartsStartingWith(bodyparts);

--- a/src/test/java/com/example/deskworkoutservice/DeskworkoutServiceTest.java
+++ b/src/test/java/com/example/deskworkoutservice/DeskworkoutServiceTest.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,7 +24,7 @@ class DeskworkoutServiceTest {
     private DeskworkoutMapper deskworkoutMapper;//インスタンス変数
 
     @Test
-    public void null又は空のクエリ文字列を渡したときに全てのレコードを取得できること() {
+    public void nullのクエリ文字列を渡したときに全てのレコードを取得できること() {
         List<Deskworkout> deskworkouts = List.of(
                 new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級"),
                 new Deskworkout(2, "バックエクステンション", "お尻を背もたれに付けたまま、デコルテを机に近づける", 10, "背中", "中級"),
@@ -34,11 +33,24 @@ class DeskworkoutServiceTest {
                 new Deskworkout(5, "スクワット", "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる", 10, "お尻", "上級")
         );
         doReturn(deskworkouts).when(deskworkoutMapper).findAll();
-        List<Deskworkout> actualEmptyString = deskworkoutService.findByBodypartsStartingWith("");
-        List<Deskworkout> actualNull = deskworkoutService.findByBodypartsStartingWith(null);
-        assertThat(actualEmptyString).isEqualTo(deskworkouts);
+        List<Deskworkout> actualNull = deskworkoutService.findByBodyPartsStartingWith(null);
         assertThat(actualNull).isEqualTo(deskworkouts);
-        verify(deskworkoutMapper, times(2)).findAll();
+        verify(deskworkoutMapper).findAll();
+    }
+
+    @Test
+    public void 空のクエリ文字列を渡したときに全てのレコードを取得できること() {
+        List<Deskworkout> deskworkouts = List.of(
+                new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級"),
+                new Deskworkout(2, "バックエクステンション", "お尻を背もたれに付けたまま、デコルテを机に近づける", 10, "背中", "中級"),
+                new Deskworkout(3, "ショルダーダウン", "肘で背もたれを押したまま、肩を引き下げる", 1, "肩", "初級"),
+                new Deskworkout(4, "ニーエクステンション", "内ももをくっ付けたまま、膝を伸ばす", 10, "脚", "初級"),
+                new Deskworkout(5, "スクワット", "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる", 10, "お尻", "上級")
+        );
+        doReturn(deskworkouts).when(deskworkoutMapper).findAll();
+        List<Deskworkout> actualEmptyString = deskworkoutService.findByBodyPartsStartingWith("");
+        assertThat(actualEmptyString).isEqualTo(deskworkouts);
+        verify(deskworkoutMapper).findAll();
     }
 
     @Test

--- a/src/test/java/com/example/deskworkoutservice/DeskworkoutServiceTest.java
+++ b/src/test/java/com/example/deskworkoutservice/DeskworkoutServiceTest.java
@@ -1,0 +1,60 @@
+package com.example.deskworkoutservice;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DeskworkoutServiceTest {
+    //@InjectMockでDeskworkoutServiceを自動的にインスタンス化し、モックオブジェクトのdeskworkoutMapperを注入する
+    @InjectMocks
+    private DeskworkoutService deskworkoutService;//インスタンス変数
+
+    @Mock
+    private DeskworkoutMapper deskworkoutMapper;//インスタンス変数
+
+    @Test
+    public void null又は空のクエリ文字列を渡したときに全てのレコードを取得できること() {
+        List<Deskworkout> deskworkouts = List.of(
+                new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級"),
+                new Deskworkout(2, "バックエクステンション", "お尻を背もたれに付けたまま、デコルテを机に近づける", 10, "背中", "中級"),
+                new Deskworkout(3, "ショルダーダウン", "肘で背もたれを押したまま、肩を引き下げる", 1, "肩", "初級"),
+                new Deskworkout(4, "ニーエクステンション", "内ももをくっ付けたまま、膝を伸ばす", 10, "脚", "初級"),
+                new Deskworkout(5, "スクワット", "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる", 10, "お尻", "上級")
+        );
+        doReturn(deskworkouts).when(deskworkoutMapper).findAll();
+        List<Deskworkout> actualEmptyString = deskworkoutService.findByBodypartsStartingWith("");
+        List<Deskworkout> actualNull = deskworkoutService.findByBodypartsStartingWith(null);
+        assertThat(actualEmptyString).isEqualTo(deskworkouts);
+        assertThat(actualNull).isEqualTo(deskworkouts);
+        verify(deskworkoutMapper, times(2)).findAll();
+    }
+
+    @Test
+    public void 存在するIDを指定したときに該当するレコードを取得できること() throws Exception {
+        doReturn(Optional.of(new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級")))
+                .when(deskworkoutMapper).findById(1);
+        Deskworkout actual = deskworkoutService.findById(1);
+        assertThat(actual).isEqualTo(new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級"));
+        verify(deskworkoutMapper).findById(1);
+    }
+
+    @Test
+    public void 存在しないIDを指定したときに例外が発生すること() {
+        doReturn(Optional.empty()).when(deskworkoutMapper).findById(100);
+        assertThatThrownBy(() -> deskworkoutService.findById(100))
+                .isInstanceOf(DeskworkoutNotFoundException.class);
+        verify(deskworkoutMapper).findById(100);
+    }
+}


### PR DESCRIPTION
# 最終課題

「デスクでできる筋トレメニュー」を管理するアプリケーションを、CRUD処理を用いて開発します。

## READ処理の単体テスト

今回はJunitを用いて、READ処理のServiceクラスに対する単体テストを実装しました。

## 検証内容

下記確認済みです。

- null又は空のクエリ文字列を渡したときに全てのレコードを取得できること
- 存在するIDを指定したときに該当するレコードを取得できること
- 存在しないIDを指定したときに例外が発生すること

## 検証結果

テスト成功しています。
![スクリーンショット 2024-07-26 171529](https://github.com/user-attachments/assets/4310e9b6-4c09-4542-a525-8d471c0e0bc6)
