### PR TITLE
ServiceクラスのCreate処理、Update処理、Delete処理についての単体テスト

### DIFF
--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
@@ -38,7 +38,7 @@ public class DeskworkoutService {
         return deskworkout;
     }
 
-    public void update(Integer id, String name, String howTo, Integer repetition, String bodyParts, String difficulty) {
+    public Deskworkout update(Integer id, String name, String howTo, Integer repetition, String bodyParts, String difficulty) {
         Deskworkout deskworkout = deskworkoutMapper.findById(id)
                 .orElseThrow(() -> new DeskworkoutNotFoundException("Workout with id:" + id + " not found"));
 
@@ -49,6 +49,7 @@ public class DeskworkoutService {
         deskworkout.setDifficulty(difficulty);
 
         deskworkoutMapper.update(deskworkout);
+        return deskworkout;
     }
 
     public void delete(int id) {

--- a/src/test/java/com/example/deskworkoutservice/DeskworkoutServiceTest.java
+++ b/src/test/java/com/example/deskworkoutservice/DeskworkoutServiceTest.java
@@ -11,7 +11,11 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -68,5 +72,51 @@ class DeskworkoutServiceTest {
         assertThatThrownBy(() -> deskworkoutService.findById(100))
                 .isInstanceOf(DeskworkoutNotFoundException.class);
         verify(deskworkoutMapper).findById(100);
+    }
+
+    @Test
+    public void 新しいレコードを登録できること() {
+        Deskworkout deskworkout = new Deskworkout("シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級");
+        assertThat(deskworkoutService.insert("シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級")).isEqualTo(deskworkout);
+        verify(deskworkoutMapper).insert(deskworkout);
+    }
+
+    @Test
+    public void レコードを更新できること() {
+        Deskworkout deskworkout = new Deskworkout(1, "name", "howTo", 10, "bodyParts", "level");
+        doReturn(Optional.of(deskworkout)).when(deskworkoutMapper).findById(1);
+        deskworkoutService.update(1, "new name", "new howTo", 5, "new bodyParts", "new level");
+        assertEquals("new name", deskworkout.getName());
+        assertEquals("new howTo", deskworkout.getHowto());
+        assertEquals(5, deskworkout.getRepetition());
+        assertEquals("new bodyParts", deskworkout.getBodyParts());
+        assertEquals("new level", deskworkout.getDifficulty());
+        verify(deskworkoutMapper).update(any(Deskworkout.class));
+    }
+
+    @Test
+    public void 存在しないIDを更新したときは例外が発生すること() {
+        doReturn(Optional.empty()).when(deskworkoutMapper).findById(100);
+        assertThrows(DeskworkoutNotFoundException.class, () -> {
+            deskworkoutService.update(100, "new name", "new howTo", 5, "new bodyParts", "new level");
+        });
+        verify(deskworkoutMapper, never()).update(any(Deskworkout.class));
+    }
+
+    @Test
+    public void 指定したIDのレコードを削除できること() {
+        Deskworkout deskworkout = new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級");
+        doReturn(Optional.of(deskworkout)).when(deskworkoutMapper).findById(1);
+        deskworkoutService.delete(1);
+        verify(deskworkoutMapper).delete(1);
+    }
+
+    @Test
+    public void 存在しないIDのレコードを削除したときに例外が発生すること() {
+        doReturn(Optional.empty()).when(deskworkoutMapper).findById(100);
+        assertThrows(DeskworkoutNotFoundException.class, () -> {
+            deskworkoutService.delete(100);
+        });
+        verify(deskworkoutMapper, never()).delete(100);
     }
 }

--- a/src/test/java/com/example/deskworkoutservice/DeskworkoutServiceTest.java
+++ b/src/test/java/com/example/deskworkoutservice/DeskworkoutServiceTest.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -59,10 +58,10 @@ class DeskworkoutServiceTest {
 
     @Test
     public void 存在するIDを指定したときに該当するレコードを取得できること() throws Exception {
-        doReturn(Optional.of(new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級")))
-                .when(deskworkoutMapper).findById(1);
+        Deskworkout deskworkout = new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級");
+        doReturn(Optional.of(deskworkout)).when(deskworkoutMapper).findById(1);
         Deskworkout actual = deskworkoutService.findById(1);
-        assertThat(actual).isEqualTo(new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級"));
+        assertThat(actual).isEqualTo(deskworkout);
         verify(deskworkoutMapper).findById(1);
     }
 
@@ -77,7 +76,8 @@ class DeskworkoutServiceTest {
     @Test
     public void 新しいレコードを登録できること() {
         Deskworkout deskworkout = new Deskworkout("シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級");
-        assertThat(deskworkoutService.insert("シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級")).isEqualTo(deskworkout);
+        Deskworkout actual = deskworkoutService.insert("シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級");
+        assertThat(actual).isEqualTo(deskworkout);
         verify(deskworkoutMapper).insert(deskworkout);
     }
 
@@ -85,12 +85,9 @@ class DeskworkoutServiceTest {
     public void レコードを更新できること() {
         Deskworkout deskworkout = new Deskworkout(1, "name", "howTo", 10, "bodyParts", "level");
         doReturn(Optional.of(deskworkout)).when(deskworkoutMapper).findById(1);
-        deskworkoutService.update(1, "new name", "new howTo", 5, "new bodyParts", "new level");
-        assertEquals("new name", deskworkout.getName());
-        assertEquals("new howTo", deskworkout.getHowto());
-        assertEquals(5, deskworkout.getRepetition());
-        assertEquals("new bodyParts", deskworkout.getBodyParts());
-        assertEquals("new level", deskworkout.getDifficulty());
+        Deskworkout actual = deskworkoutService.update(1, "new name", "new howTo", 5, "new bodyParts", "new level");
+        //既存のオブジェクトが更新済みであることを確認
+        assertThat(actual).isEqualTo(deskworkout);
         verify(deskworkoutMapper).update(any(Deskworkout.class));
     }
 


### PR DESCRIPTION
# 最終課題

「デスクでできる筋トレメニュー」を管理するアプリケーションをCRUD処理を用いて開発します。

## 概要

ServiceクラスのCreate処理、Delete処理、Update処理についての単体テストを実装しました。

## 動作確認

下記確認済みです。

- 新しいレコードを登録できること
![登録](https://github.com/user-attachments/assets/36ea8bde-b182-40f9-8e62-809583e69a91)

- 指定したIDが存在した場合レコードを更新できること
![更新](https://github.com/user-attachments/assets/63575834-7107-4f06-aa4d-a9c75cd6a983)

- 指定したIDが存在しない場合例外が発生すること
![更新　例外](https://github.com/user-attachments/assets/7d7ebd57-4b37-4f79-a296-3565f0206267)

- 指定したIDが存在した場合レコードを削除できること
![削除](https://github.com/user-attachments/assets/a3a219f9-ca2b-4e38-8081-fc46885f82f5)


- 指定したIDが存在しない場合例外が発生すること
![削除　例外](https://github.com/user-attachments/assets/ea6b261c-a01e-4cec-ab90-0f7e4611ceec)

