### PR TITLE
CRUD処理のDBテスト実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.hibernate:hibernate-core:5.6.4.Final'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.github.database-rider:rider-spring:1.44.0'
+
 }
 
 tasks.named('test') {

--- a/src/test/java/com/example/deskworkoutservice/DeskworkoutMapperTest.java
+++ b/src/test/java/com/example/deskworkoutservice/DeskworkoutMapperTest.java
@@ -1,6 +1,7 @@
 package com.example.deskworkoutservice;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -55,9 +56,10 @@ class DeskworkoutMapperTest {
 
     @Test
     @DataSet(value = "datasets/deskworkouts.yml")
+    @ExpectedDataSet(value = "expected-datasets/deskworkouts-after-insert.yml", ignoreCols = "id")
     @Transactional
     void 新しいレコードを登録できること() {
-        Deskworkout deskworkout = new Deskworkout("シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級");
+        Deskworkout deskworkout = new Deskworkout("new name", "new howTo", 5, "new bodyParts", "new level");
         deskworkoutMapper.insert(deskworkout);
         Optional<Deskworkout> actual = deskworkoutMapper.findById(deskworkout.getId());
         assertThat(actual).isPresent();
@@ -66,6 +68,7 @@ class DeskworkoutMapperTest {
 
     @Test
     @DataSet(value = "datasets/deskworkouts.yml")
+    @ExpectedDataSet(value = "expected-datasets/deskworkouts-after-update.yml")
     @Transactional
     void 指定したIDが存在するときにそのレコードを更新できること() {
         Deskworkout newDeskworkout = new Deskworkout(1, "new name", "new howTo", 5, "new bodyParts", "new level");
@@ -77,6 +80,7 @@ class DeskworkoutMapperTest {
 
     @Test
     @DataSet(value = "datasets/deskworkouts.yml")
+    @ExpectedDataSet(value = "expected-datasets/deskworkouts-after-delete.yml")
     @Transactional
     void 指定したIDが存在するときにそのレコードを削除できること() {
         deskworkoutMapper.delete(1);

--- a/src/test/java/com/example/deskworkoutservice/DeskworkoutMapperTest.java
+++ b/src/test/java/com/example/deskworkoutservice/DeskworkoutMapperTest.java
@@ -1,0 +1,86 @@
+package com.example.deskworkoutservice;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class DeskworkoutMapperTest {
+
+    @Autowired
+    DeskworkoutMapper deskworkoutMapper;
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void レコードを全件取得できること() {
+        List<Deskworkout> actual = deskworkoutMapper.findAll();
+        assertThat(actual)
+                .hasSize(5)
+                .contains(
+                        new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級"),
+                        new Deskworkout(2, "バックエクステンション", "お尻を背もたれに付けたまま、デコルテを机に近づける", 10, "背中", "中級"),
+                        new Deskworkout(3, "ショルダーダウン", "肘で背もたれを押したまま、肩を引き下げる", 1, "肩", "初級"),
+                        new Deskworkout(4, "ニーエクステンション", "内ももをくっ付けたまま、膝を伸ばす", 10, "脚", "初級"),
+                        new Deskworkout(5, "スクワット", "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる", 10, "お尻", "上級")
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 指定したIDが存在するときにそのレコードを取得できること() {
+        Optional<Deskworkout> actual = deskworkoutMapper.findById(1);
+        assertThat(actual).hasValue(new Deskworkout(1, "シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級"));
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 指定したIDが存在しないときに空のOptionalが返されること() {
+        Optional<Deskworkout> actual = deskworkoutMapper.findById(100);
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 新しいレコードを登録できること() {
+        Deskworkout deskworkout = new Deskworkout("シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級");
+        deskworkoutMapper.insert(deskworkout);
+        Optional<Deskworkout> actual = deskworkoutMapper.findById(deskworkout.getId());
+        assertThat(actual).isPresent();
+        assertThat(actual).hasValue(deskworkout);
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 指定したIDが存在するときにそのレコードを更新できること() {
+        Deskworkout newDeskworkout = new Deskworkout(1, "new name", "new howTo", 5, "new bodyParts", "new level");
+        deskworkoutMapper.update(newDeskworkout);
+        Optional<Deskworkout> actual = deskworkoutMapper.findById(1);
+        assertThat(actual).isPresent();
+        assertThat(actual).hasValue(newDeskworkout);
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 指定したIDが存在するときにそのレコードを削除できること() {
+        deskworkoutMapper.delete(1);
+        Optional<Deskworkout> actual = deskworkoutMapper.findById(1);
+        assertThat(actual).isEmpty();
+    }
+}

--- a/src/test/resources/datasets/deskworkouts.yml
+++ b/src/test/resources/datasets/deskworkouts.yml
@@ -1,0 +1,31 @@
+deskworkouts:
+  - id: 1
+    name: "シットアップ"
+    howTo: "直角に曲げた膝を机裏にタッチする"
+    repetition: 10
+    bodyParts: "お腹"
+    difficulty: "初級"
+  - id: 2
+    name: "バックエクステンション"
+    howTo: "お尻を背もたれに付けたまま、デコルテを机に近づける"
+    repetition: 10
+    bodyParts: "背中"
+    difficulty: "中級"
+  - id: 3
+    name: "ショルダーダウン"
+    howTo: "肘で背もたれを押したまま、肩を引き下げる"
+    repetition: 1
+    bodyParts: "肩"
+    difficulty: "初級"
+  - id: 4
+    name: "ニーエクステンション"
+    howTo: "内ももをくっ付けたまま、膝を伸ばす"
+    repetition: 10
+    bodyParts: "脚"
+    difficulty: "初級"
+  - id: 5
+    name: "スクワット"
+    howTo: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
+    repetition: 10
+    bodyParts: "お尻"
+    difficulty: "上級"

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,0 +1,9 @@
+cacheConnection: false
+cacheTableNames: false
+properties:
+  schema: deskworkout_database
+caseInsensitiveStrategy: LOWERCASE
+connectionConfig:
+  url: "jdbc:mysql://localhost:3307/deskworkout_database" # MySQLの場合
+  user: "user"
+  password: "password"

--- a/src/test/resources/expected-datasets/deskworkouts-after-delete.yml
+++ b/src/test/resources/expected-datasets/deskworkouts-after-delete.yml
@@ -1,0 +1,25 @@
+deskworkouts:
+  - id: 2
+    name: "バックエクステンション"
+    howTo: "お尻を背もたれに付けたまま、デコルテを机に近づける"
+    repetition: 10
+    bodyParts: "背中"
+    difficulty: "中級"
+  - id: 3
+    name: "ショルダーダウン"
+    howTo: "肘で背もたれを押したまま、肩を引き下げる"
+    repetition: 1
+    bodyParts: "肩"
+    difficulty: "初級"
+  - id: 4
+    name: "ニーエクステンション"
+    howTo: "内ももをくっ付けたまま、膝を伸ばす"
+    repetition: 10
+    bodyParts: "脚"
+    difficulty: "初級"
+  - id: 5
+    name: "スクワット"
+    howTo: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
+    repetition: 10
+    bodyParts: "お尻"
+    difficulty: "上級"

--- a/src/test/resources/expected-datasets/deskworkouts-after-insert.yml
+++ b/src/test/resources/expected-datasets/deskworkouts-after-insert.yml
@@ -1,0 +1,37 @@
+deskworkouts:
+  - id: 1
+    name: "シットアップ"
+    howTo: "直角に曲げた膝を机裏にタッチする"
+    repetition: 10
+    bodyParts: "お腹"
+    difficulty: "初級"
+  - id: 2
+    name: "バックエクステンション"
+    howTo: "お尻を背もたれに付けたまま、デコルテを机に近づける"
+    repetition: 10
+    bodyParts: "背中"
+    difficulty: "中級"
+  - id: 3
+    name: "ショルダーダウン"
+    howTo: "肘で背もたれを押したまま、肩を引き下げる"
+    repetition: 1
+    bodyParts: "肩"
+    difficulty: "初級"
+  - id: 4
+    name: "ニーエクステンション"
+    howTo: "内ももをくっ付けたまま、膝を伸ばす"
+    repetition: 10
+    bodyParts: "脚"
+    difficulty: "初級"
+  - id: 5
+    name: "スクワット"
+    howTo: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
+    repetition: 10
+    bodyParts: "お尻"
+    difficulty: "上級"
+  - id: 6
+    name: "new name"
+    howTo: "new howTo"
+    repetition: 5
+    bodyParts: "new bodyParts"
+    difficulty: "new level"

--- a/src/test/resources/expected-datasets/deskworkouts-after-update.yml
+++ b/src/test/resources/expected-datasets/deskworkouts-after-update.yml
@@ -1,0 +1,31 @@
+deskworkouts:
+  - id: 1
+    name: "new name"
+    howTo: "new howTo"
+    repetition: 5
+    bodyParts: "new bodyParts"
+    difficulty: "new level"
+  - id: 2
+    name: "バックエクステンション"
+    howTo: "お尻を背もたれに付けたまま、デコルテを机に近づける"
+    repetition: 10
+    bodyParts: "背中"
+    difficulty: "中級"
+  - id: 3
+    name: "ショルダーダウン"
+    howTo: "肘で背もたれを押したまま、肩を引き下げる"
+    repetition: 1
+    bodyParts: "肩"
+    difficulty: "初級"
+  - id: 4
+    name: "ニーエクステンション"
+    howTo: "内ももをくっ付けたまま、膝を伸ばす"
+    repetition: 10
+    bodyParts: "脚"
+    difficulty: "初級"
+  - id: 5
+    name: "スクワット"
+    howTo: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
+    repetition: 10
+    bodyParts: "お尻"
+    difficulty: "上級"


### PR DESCRIPTION
# 最終課題

「デスクでできる筋トレメニュー」を管理するアプリケーションをCRUD処理を用いて開発します。

## 概要

DB Riderを用いてCRUD処理のDBテストを実装しました。

## 動作確認

下記確認済みです。

- 新しいレコードを登録できること
![create](https://github.com/user-attachments/assets/60286801-9b81-4124-9963-59a246d8ff78)

- レコードを全件取得できること
![read 全件取得](https://github.com/user-attachments/assets/913c7000-dd54-4906-a06b-8cc60cc76666)

- 指定したIDが存在するときにそのレコードを取得できること
![read ID検索](https://github.com/user-attachments/assets/aee4b88d-2ab8-4e12-a5ce-de4f8059d49d)

- 指定したIDが存在しないときに空のOptionalが返ること
![ID検索　空文字返す](https://github.com/user-attachments/assets/88b572d0-b363-419a-8b3b-0d303cc265c1)


- 指定したIDが存在するときにそのレコードを更新できること
![Update](https://github.com/user-attachments/assets/88c71599-ed1f-4dfc-bf54-bb5b29a9b6f2)


- 指定したIDが存在するときにそのレコードを削除できること
![Delete](https://github.com/user-attachments/assets/f2ca96ed-c61d-4b4b-9c61-bf493d4dea6d)
