### PR TITLE
CRUD処理の結合テスト実装

### DIFF
--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -3,15 +3,15 @@ DROP TABLE IF EXISTS deskworkouts;
 CREATE TABLE deskworkouts (
   id int unsigned AUTO_INCREMENT,
   name VARCHAR(20) NOT NULL,
-  howTo VARCHAR(200) NOT NULL DEFAULT '未設定',
+  howto VARCHAR(200) NOT NULL DEFAULT '未設定',
   repetition INT NOT NULL DEFAULT 0,
   bodyParts VARCHAR(100)  NOT NULL DEFAULT '未設定',
   difficulty VARCHAR(20)  NOT NULL DEFAULT '未設定',
   PRIMARY KEY(id)
 );
 
-INSERT INTO deskworkouts (name, howTo, repetition, bodyParts, difficulty ) VALUES ("シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級");
-INSERT INTO deskworkouts (name, howTo, repetition, bodyParts, difficulty) VALUES  ("バックエクステンション", "お尻を背もたれに付けたまま、デコルテを机に近づける", 10, "背中", "中級");
-INSERT INTO deskworkouts (name, howTo, repetition, bodyParts, difficulty ) VALUES ("ショルダーダウン", "肘で背もたれを押したまま、肩を引き下げる", 1, "肩", "初級");
-INSERT INTO deskworkouts (name, howTo, repetition, bodyParts, difficulty) VALUES  ("ニーエクステンション", "内ももをくっ付けたまま、膝を伸ばす", 10, "脚", "初級");
-INSERT INTO deskworkouts (name, howTo, repetition, bodyParts, difficulty ) VALUES ("スクワット", "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる", 10, "お尻", "上級");
+INSERT INTO deskworkouts (name, howto, repetition, bodyParts, difficulty ) VALUES ("シットアップ", "直角に曲げた膝を机裏にタッチする", 10, "お腹", "初級");
+INSERT INTO deskworkouts (name, howto, repetition, bodyParts, difficulty) VALUES  ("バックエクステンション", "お尻を背もたれに付けたまま、デコルテを机に近づける", 10, "背中", "中級");
+INSERT INTO deskworkouts (name, howto, repetition, bodyParts, difficulty ) VALUES ("ショルダーダウン", "肘で背もたれを押したまま、肩を引き下げる", 1, "肩", "初級");
+INSERT INTO deskworkouts (name, howto, repetition, bodyParts, difficulty) VALUES  ("ニーエクステンション", "内ももをくっ付けたまま、膝を伸ばす", 10, "脚", "初級");
+INSERT INTO deskworkouts (name, howto, repetition, bodyParts, difficulty ) VALUES ("スクワット", "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる", 10, "お尻", "上級");

--- a/src/main/java/com/example/deskworkoutservice/Deskworkout.java
+++ b/src/main/java/com/example/deskworkoutservice/Deskworkout.java
@@ -19,7 +19,7 @@ public class Deskworkout {
     private String name;
 
     @Column(length = 200, nullable = false, columnDefinition = "VARCHAR(200) DEFAULT '未設定'")
-    private String howTo;
+    private String howto;
 
     @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
     private Integer repetition;
@@ -30,19 +30,19 @@ public class Deskworkout {
     @Column(length = 20, nullable = false, columnDefinition = "VARCHAR(20) DEFAULT '未設定'")
     private String difficulty;
 
-    public Deskworkout(int id, String name, String howTo, int repetition, String bodyParts, String difficulty) {
+    public Deskworkout(int id, String name, String howto, int repetition, String bodyParts, String difficulty) {
         this.id = id;
         this.name = name;
-        this.howTo = howTo;
+        this.howto = howto;
         this.repetition = repetition;
         this.bodyParts = bodyParts;
         this.difficulty = difficulty;
     }
 
-    public Deskworkout(String name, String howTo, int repetition, String bodyParts, String difficulty) {
+    public Deskworkout(String name, String howto, int repetition, String bodyParts, String difficulty) {
         // id は INSERT文発行時に MySQLによって自動採番した値が補完されるので null を設定
         this.name = name;
-        this.howTo = howTo;
+        this.howto = howto;
         this.repetition = repetition;
         this.bodyParts = bodyParts;
         this.difficulty = difficulty;
@@ -61,7 +61,7 @@ public class Deskworkout {
     }
 
     public String getHowto() {
-        return howTo;
+        return howto;
     }
 
     public int getRepetition() {
@@ -84,8 +84,8 @@ public class Deskworkout {
         this.name = name;
     }
 
-    public void setHowto(String howTo) {
-        this.howTo = howTo;
+    public void setHowto(String howto) {
+        this.howto = howto;
     }
 
     public void setRepetition(int repetition) {
@@ -108,7 +108,7 @@ public class Deskworkout {
         Deskworkout that = (Deskworkout) o;
         return repetition == that.repetition &&
                 Objects.equals(name, that.name) &&
-                Objects.equals(howTo, that.howTo) &&
+                Objects.equals(howto, that.howto) &&
                 Objects.equals(bodyParts, that.bodyParts) &&
                 Objects.equals(difficulty, that.difficulty);
     }
@@ -116,14 +116,14 @@ public class Deskworkout {
     // hashCode メソッドのオーバーライド
     @Override
     public int hashCode() {
-        return Objects.hash(name, howTo, repetition, bodyParts, difficulty);
+        return Objects.hash(name, howto, repetition, bodyParts, difficulty);
     }
 
     @Override
     public String toString() {
         return "{\"id\":" + id +
                 ",\"name\":\"" + name + "\"" +
-                ",\"howto\":\"" + howTo + "\"" +
+                ",\"howto\":\"" + howto + "\"" +
                 ",\"repetition\":" + repetition +
                 ",\"bodyparts\":\"" + bodyParts + "\"" +
                 ",\"difficulty\":\"" + difficulty + "\"}";

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutController.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutController.java
@@ -38,7 +38,7 @@ public class DeskworkoutController {
     public ResponseEntity<DeskworkoutResponse> insert(@RequestBody @Valid DeskworkoutRequest deskworkoutRequest, UriComponentsBuilder uriBuilder) {
         Deskworkout deskworkout = deskworkoutService.insert(
                 deskworkoutRequest.getName(),
-                deskworkoutRequest.getHowTo(),
+                deskworkoutRequest.getHowto(),
                 deskworkoutRequest.getRepetition(),
                 deskworkoutRequest.getBodyParts(),
                 deskworkoutRequest.getDifficulty()
@@ -53,7 +53,7 @@ public class DeskworkoutController {
         deskworkoutService.update(
                 id,
                 deskworkoutRequest.getName(),
-                deskworkoutRequest.getHowTo(),
+                deskworkoutRequest.getHowto(),
                 deskworkoutRequest.getRepetition(),
                 deskworkoutRequest.getBodyParts(),
                 deskworkoutRequest.getDifficulty());

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutMapper.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutMapper.java
@@ -22,11 +22,11 @@ public interface DeskworkoutMapper {
     @Select("SELECT * FROM deskworkouts WHERE id = #{id}")
     Optional<Deskworkout> findById(int id);
 
-    @Insert("INSERT INTO deskworkouts  (name, howTo, repetition, bodyParts, difficulty ) VALUES (#{name},#{howTo},#{repetition},#{bodyParts},#{difficulty})")
+    @Insert("INSERT INTO deskworkouts  (name, howto, repetition, bodyParts, difficulty ) VALUES (#{name},#{howto},#{repetition},#{bodyParts},#{difficulty})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void insert(Deskworkout deskworkout);
 
-    @Update("UPDATE deskworkouts SET name=#{name}, howTo=#{howTo}, repetition=#{repetition}, bodyParts=#{bodyParts}, difficulty=#{difficulty} WHERE id = #{id}")
+    @Update("UPDATE deskworkouts SET name=#{name}, howto=#{howto}, repetition=#{repetition}, bodyParts=#{bodyParts}, difficulty=#{difficulty} WHERE id = #{id}")
     void update(Deskworkout deskworkout);
 
     @Delete("DELETE FROM deskworkouts WHERE id = #{id}")

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutRequest.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutRequest.java
@@ -14,7 +14,7 @@ public class DeskworkoutRequest {
 
     @NotBlank(message = "空白は許可されていません")
     @Size(max = 100, message = "動作説明は{max}文字以内で入力してください")
-    private String howTo;
+    private String howto;
 
     @NotNull(message = "空白は許可されていません")
     @Positive(message = "レップ数は自然数で入力してください")
@@ -28,9 +28,9 @@ public class DeskworkoutRequest {
     @Size(max = 20, message = "難易度は{max}文字以内で入力してください")
     private String difficulty;
 
-    public DeskworkoutRequest(String name, String howTo, int repetition, String bodyParts, String difficulty) {
+    public DeskworkoutRequest(String name, String howto, int repetition, String bodyParts, String difficulty) {
         this.name = name;
-        this.howTo = howTo;
+        this.howto = howto;
         this.repetition = repetition;
         this.bodyParts = bodyParts;
         this.difficulty = difficulty;
@@ -40,8 +40,8 @@ public class DeskworkoutRequest {
         return name;
     }
 
-    public String getHowTo() {
-        return howTo;
+    public String getHowto() {
+        return howto;
     }
 
     public int getRepetition() {

--- a/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
+++ b/src/main/java/com/example/deskworkoutservice/DeskworkoutService.java
@@ -27,10 +27,10 @@ public class DeskworkoutService {
                 .orElseThrow(() -> new DeskworkoutNotFoundException("Workout with id:" + id + " not found"));
     }
 
-    public Deskworkout insert(String name, String howTo, Integer repetition, String bodyParts, String difficulty) {
+    public Deskworkout insert(String name, String howto, Integer repetition, String bodyParts, String difficulty) {
         Deskworkout deskworkout = new Deskworkout();
         deskworkout.setName(name);
-        deskworkout.setHowto(howTo);
+        deskworkout.setHowto(howto);
         deskworkout.setRepetition(repetition);
         deskworkout.setBodyParts(bodyParts);
         deskworkout.setDifficulty(difficulty);
@@ -38,12 +38,12 @@ public class DeskworkoutService {
         return deskworkout;
     }
 
-    public Deskworkout update(Integer id, String name, String howTo, Integer repetition, String bodyParts, String difficulty) {
+    public Deskworkout update(Integer id, String name, String howto, Integer repetition, String bodyParts, String difficulty) {
         Deskworkout deskworkout = deskworkoutMapper.findById(id)
                 .orElseThrow(() -> new DeskworkoutNotFoundException("Workout with id:" + id + " not found"));
 
         deskworkout.setName(name);
-        deskworkout.setHowto(howTo);
+        deskworkout.setHowto(howto);
         deskworkout.setRepetition(repetition);
         deskworkout.setBodyParts(bodyParts);
         deskworkout.setDifficulty(difficulty);

--- a/src/test/java/com/example/deskworkoutservice/DeskworkoutserviceApplicationTests.java
+++ b/src/test/java/com/example/deskworkoutservice/DeskworkoutserviceApplicationTests.java
@@ -6,8 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class DeskworkoutserviceApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+    @Test
+    void contextLoads() {
+    }
 }

--- a/src/test/java/com/example/deskworkoutservice/integrationtest/DeskworkoutRestApiIntegrationTest.java
+++ b/src/test/java/com/example/deskworkoutservice/integrationtest/DeskworkoutRestApiIntegrationTest.java
@@ -1,0 +1,299 @@
+package com.example.deskworkoutservice.integrationtest;
+
+import com.example.deskworkoutservice.DeskworkoutserviceApplication;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@SpringBootTest(classes = DeskworkoutserviceApplication.class)
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class DeskworkoutRestApiIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    //Read処理の結合テスト
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void null又は空のクエリ文字列を渡したときに全件取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                            {
+                                "id": 1,
+                                "name": "シットアップ",
+                                "howto": "直角に曲げた膝を机裏にタッチする",
+                                "repetition": 10,
+                                "bodyParts": "お腹",
+                                "difficulty": "初級"
+                            },
+                            {
+                                "id": 2,
+                                "name": "バックエクステンション",
+                                "howto": "お尻を背もたれに付けたまま、デコルテを机に近づける",
+                                "repetition": 10,
+                                "bodyParts": "背中",
+                                "difficulty": "中級"
+                            },
+                            {
+                                "id": 3,
+                                "name": "ショルダーダウン",
+                                "howto": "肘で背もたれを押したまま、肩を引き下げる",
+                                "repetition": 1,
+                                "bodyParts": "肩",
+                                "difficulty": "初級"
+                            },
+                            {
+                                "id": 4,
+                                "name": "ニーエクステンション",
+                                "howto": "内ももをくっ付けたまま、膝を伸ばす",
+                                "repetition": 10,
+                                "bodyParts": "脚",
+                                "difficulty": "初級"
+                            },
+                            {
+                                "id": 5,
+                                "name": "スクワット",
+                                "howto": "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる",
+                                "repetition": 10,
+                                "bodyParts": "お尻",
+                                "difficulty": "上級"
+                            }
+                        ]
+                        """, true));
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 存在しないクエリ文字列を指定したときに空文字が返ること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts?=bodyParts=腕"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("[]"));
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 正常なクエリ文字列を渡したときそのレコードを取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts?bodyParts=お腹"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                            {
+                                "id": 1,
+                                "name": "シットアップ",
+                                "howto": "直角に曲げた膝を机裏にタッチする",
+                                "repetition": 10,
+                                "bodyParts": "お腹",
+                                "difficulty": "初級"
+                            }
+                        ]
+                        """, true));
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 存在するIDを指定したときにそのレコードを取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts/2"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "id": 2,
+                            "name": "バックエクステンション",
+                            "howto": "お尻を背もたれに付けたまま、デコルテを机に近づける",
+                            "repetition": 10,
+                            "bodyParts": "背中",
+                            "difficulty": "中級"
+                        }
+                        """, true));
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 存在しないIDを指定したとき例外が発生すること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts/100"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                //JSONボディ内のstatusフィールドが404であることを確認
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("404"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("Workout with id:100 not found"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Not Found"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/deskworkouts/100"));
+    }
+
+    //Create処理の結合テスト
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @ExpectedDataSet(value = "expected-datasets/deskworkouts-after-insert.yml", ignoreCols = "id")
+    @Transactional
+    void 新しいレコードを登録できること() throws Exception {
+        String newDeskworkout = """
+                {
+                    "name": "new name",
+                    "howto": "new howTo",
+                    "repetition": 5,
+                    "bodyParts": "new bodyParts",
+                    "difficulty": "new level"
+                }
+                """;
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/deskworkouts")
+                        .contentType(APPLICATION_JSON)
+                        .content(newDeskworkout))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "message": "deskworkout created"
+                        }
+                        """));
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 不正なデータを登録したときに例外が発生すること() throws Exception {
+        String invalidDeskworkout = """
+                {
+                    "name": "あいうえおかきくけこさしすせそたちつてと",
+                    "howto": "　",
+                    "repetition": -1,
+                    "bodyParts": " ",
+                    "difficulty":""
+                }
+                """;
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/deskworkouts")
+                        .contentType(APPLICATION_JSON)
+                        .content(invalidDeskworkout))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "repetition": "レップ数は自然数で入力してください",
+                            "bodyParts": "空白は許可されていません",
+                            "difficulty": "空白は許可されていません"
+                        }
+                        """, true));
+    }
+
+    //Update処理の結合テスト
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @ExpectedDataSet(value = "expected-datasets/deskworkouts-after-update.yml")
+    @Transactional
+    void 存在するIDを指定したときにそのレコードを更新できること() throws Exception {
+        String newDeskworkout = """
+                {
+                    "name": "new name",
+                    "howto": "new howTo",
+                    "repetition": 5,
+                    "bodyParts": "new bodyParts",
+                    "difficulty": "new level"
+                }
+                """;
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/deskworkouts/1")
+                        .contentType(APPLICATION_JSON)
+                        .content(newDeskworkout))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "message": "deskworkout updated"
+                        }
+                        """));
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 存在しないIDを指定したときに例外が発生し更新できないこと() throws Exception {
+        String notFoundDeskworkout = """
+                {
+                    "name": "new name",
+                    "howto": "new howTo",
+                    "repetition": 5,
+                    "bodyParts": "new bodyParts",
+                    "difficulty": "new level"
+                }
+                """;
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/deskworkouts/100")
+                        .contentType(APPLICATION_JSON)
+                        .content(notFoundDeskworkout))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("404"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("Workout with id:100 not found"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Not Found"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/deskworkouts/100"));
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 不正なデータを更新したときに例外が発生する() throws Exception {
+        String invalidDeskworkout = """
+                {
+                    "name": "あいうえおかきくけこさしすせそたちつてと",
+                    "howto": "　",
+                    "repetition": -1,
+                    "bodyParts": " ",
+                    "difficulty":""
+                }
+                """;
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/deskworkouts/2")
+                        .contentType(APPLICATION_JSON)
+                        .content(invalidDeskworkout))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "repetition": "レップ数は自然数で入力してください",
+                            "bodyParts": "空白は許可されていません",
+                            "difficulty": "空白は許可されていません"
+                        }
+                        """, true));
+    }
+
+    //Delete処理の結合テスト
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @ExpectedDataSet(value = "expected-datasets/deskworkouts-after-delete.yml")
+    @Transactional
+    void 存在するIDを指定したときにそのレコードを削除できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/deskworkouts/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "message": "deskworkout deleted"
+                        }
+                        """));
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 存在しないIDを指定したときに例外が発生しレコードを削除できないこと() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/deskworkouts/100"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("404"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("Workout with id:100 not found"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Not Found"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/deskworkouts/100"));
+    }
+}

--- a/src/test/java/com/example/deskworkoutservice/integrationtest/DeskworkoutRestApiIntegrationTest.java
+++ b/src/test/java/com/example/deskworkoutservice/integrationtest/DeskworkoutRestApiIntegrationTest.java
@@ -81,7 +81,7 @@ public class DeskworkoutRestApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/deskworkouts.yml")
     @Transactional
-    void 存在しないクエリ文字列を指定したときに空文字が返ること() throws Exception {
+    void 存在しないクエリ文字列を指定したときに空の配列が返ること() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts?=bodyParts=腕"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("[]"));

--- a/src/test/java/com/example/deskworkoutservice/mapper/DeskworkoutMapperTest.java
+++ b/src/test/java/com/example/deskworkoutservice/mapper/DeskworkoutMapperTest.java
@@ -1,5 +1,7 @@
-package com.example.deskworkoutservice;
+package com.example.deskworkoutservice.mapper;
 
+import com.example.deskworkoutservice.Deskworkout;
+import com.example.deskworkoutservice.DeskworkoutMapper;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
@@ -7,8 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/test/java/com/example/deskworkoutservice/service/DeskworkoutServiceTest.java
+++ b/src/test/java/com/example/deskworkoutservice/service/DeskworkoutServiceTest.java
@@ -1,5 +1,9 @@
-package com.example.deskworkoutservice;
+package com.example.deskworkoutservice.service;
 
+import com.example.deskworkoutservice.Deskworkout;
+import com.example.deskworkoutservice.DeskworkoutMapper;
+import com.example.deskworkoutservice.DeskworkoutNotFoundException;
+import com.example.deskworkoutservice.DeskworkoutService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/src/test/resources/datasets/deskworkouts.yml
+++ b/src/test/resources/datasets/deskworkouts.yml
@@ -1,31 +1,31 @@
 deskworkouts:
   - id: 1
     name: "シットアップ"
-    howTo: "直角に曲げた膝を机裏にタッチする"
+    howto: "直角に曲げた膝を机裏にタッチする"
     repetition: 10
     bodyParts: "お腹"
     difficulty: "初級"
   - id: 2
     name: "バックエクステンション"
-    howTo: "お尻を背もたれに付けたまま、デコルテを机に近づける"
+    howto: "お尻を背もたれに付けたまま、デコルテを机に近づける"
     repetition: 10
     bodyParts: "背中"
     difficulty: "中級"
   - id: 3
     name: "ショルダーダウン"
-    howTo: "肘で背もたれを押したまま、肩を引き下げる"
+    howto: "肘で背もたれを押したまま、肩を引き下げる"
     repetition: 1
     bodyParts: "肩"
     difficulty: "初級"
   - id: 4
     name: "ニーエクステンション"
-    howTo: "内ももをくっ付けたまま、膝を伸ばす"
+    howto: "内ももをくっ付けたまま、膝を伸ばす"
     repetition: 10
     bodyParts: "脚"
     difficulty: "初級"
   - id: 5
     name: "スクワット"
-    howTo: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
+    howto: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
     repetition: 10
     bodyParts: "お尻"
     difficulty: "上級"

--- a/src/test/resources/expected-datasets/deskworkouts-after-delete.yml
+++ b/src/test/resources/expected-datasets/deskworkouts-after-delete.yml
@@ -1,25 +1,25 @@
 deskworkouts:
   - id: 2
     name: "バックエクステンション"
-    howTo: "お尻を背もたれに付けたまま、デコルテを机に近づける"
+    howto: "お尻を背もたれに付けたまま、デコルテを机に近づける"
     repetition: 10
     bodyParts: "背中"
     difficulty: "中級"
   - id: 3
     name: "ショルダーダウン"
-    howTo: "肘で背もたれを押したまま、肩を引き下げる"
+    howto: "肘で背もたれを押したまま、肩を引き下げる"
     repetition: 1
     bodyParts: "肩"
     difficulty: "初級"
   - id: 4
     name: "ニーエクステンション"
-    howTo: "内ももをくっ付けたまま、膝を伸ばす"
+    howto: "内ももをくっ付けたまま、膝を伸ばす"
     repetition: 10
     bodyParts: "脚"
     difficulty: "初級"
   - id: 5
     name: "スクワット"
-    howTo: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
+    howto: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
     repetition: 10
     bodyParts: "お尻"
     difficulty: "上級"

--- a/src/test/resources/expected-datasets/deskworkouts-after-insert.yml
+++ b/src/test/resources/expected-datasets/deskworkouts-after-insert.yml
@@ -1,37 +1,37 @@
 deskworkouts:
   - id: 1
     name: "シットアップ"
-    howTo: "直角に曲げた膝を机裏にタッチする"
+    howto: "直角に曲げた膝を机裏にタッチする"
     repetition: 10
     bodyParts: "お腹"
     difficulty: "初級"
   - id: 2
     name: "バックエクステンション"
-    howTo: "お尻を背もたれに付けたまま、デコルテを机に近づける"
+    howto: "お尻を背もたれに付けたまま、デコルテを机に近づける"
     repetition: 10
     bodyParts: "背中"
     difficulty: "中級"
   - id: 3
     name: "ショルダーダウン"
-    howTo: "肘で背もたれを押したまま、肩を引き下げる"
+    howto: "肘で背もたれを押したまま、肩を引き下げる"
     repetition: 1
     bodyParts: "肩"
     difficulty: "初級"
   - id: 4
     name: "ニーエクステンション"
-    howTo: "内ももをくっ付けたまま、膝を伸ばす"
+    howto: "内ももをくっ付けたまま、膝を伸ばす"
     repetition: 10
     bodyParts: "脚"
     difficulty: "初級"
   - id: 5
     name: "スクワット"
-    howTo: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
+    howto: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
     repetition: 10
     bodyParts: "お尻"
     difficulty: "上級"
   - id: 6
     name: "new name"
-    howTo: "new howTo"
+    howto: "new howTo"
     repetition: 5
     bodyParts: "new bodyParts"
     difficulty: "new level"

--- a/src/test/resources/expected-datasets/deskworkouts-after-update.yml
+++ b/src/test/resources/expected-datasets/deskworkouts-after-update.yml
@@ -1,31 +1,31 @@
 deskworkouts:
   - id: 1
     name: "new name"
-    howTo: "new howTo"
+    howto: "new howTo"
     repetition: 5
     bodyParts: "new bodyParts"
     difficulty: "new level"
   - id: 2
     name: "バックエクステンション"
-    howTo: "お尻を背もたれに付けたまま、デコルテを机に近づける"
+    howto: "お尻を背もたれに付けたまま、デコルテを机に近づける"
     repetition: 10
     bodyParts: "背中"
     difficulty: "中級"
   - id: 3
     name: "ショルダーダウン"
-    howTo: "肘で背もたれを押したまま、肩を引き下げる"
+    howto: "肘で背もたれを押したまま、肩を引き下げる"
     repetition: 1
     bodyParts: "肩"
     difficulty: "初級"
   - id: 4
     name: "ニーエクステンション"
-    howTo: "内ももをくっ付けたまま、膝を伸ばす"
+    howto: "内ももをくっ付けたまま、膝を伸ばす"
     repetition: 10
     bodyParts: "脚"
     difficulty: "初級"
   - id: 5
     name: "スクワット"
-    howTo: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
+    howto: "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる"
     repetition: 10
     bodyParts: "お尻"
     difficulty: "上級"


### PR DESCRIPTION
# 最終課題

「デスクでできる筋トレメニュー」を管理するアプリケーションをCRUD処理を用いて開発します。

## 概要

MockMvcを用いてCRUD処理の結合テストを実装しました。

## 動作確認

APIの仕様に基づいて作成しました。
テスト成功済です。

Read処理
- null又は空のクエリ文字列を渡したときに全件取得できること(200)
![全件取得](https://github.com/user-attachments/assets/a2e4b752-7375-413a-8c56-8cb9e545e002)

- 存在しないクエリ文字列を指定したときに空文字が返ること(200)
![取得　クエリ検索　空文字返す](https://github.com/user-attachments/assets/938b7092-1ceb-46d6-b59e-2947d4aba188)

- 正常なクエリ文字列を渡したときにそのレコードを取得できること(200)
![取得　クエリ検索　正常](https://github.com/user-attachments/assets/673c60c6-8270-4e16-a057-de254911b637)

- 存在するIDを指定したときにそのレコードを取得できること(200)
![取得　ID指定](https://github.com/user-attachments/assets/277936fc-fc54-4d70-ab17-e372a36b86d5)

- 存在しないIDを指定したときに例外が発生すること(404)
![登録　不正なデータ](https://github.com/user-attachments/assets/02f8d970-3141-47b9-83f8-38c892c414dc)

Create処理

- 新しいレコードを登録できること(201)
![スクリーンショット 2024-08-20 170842](https://github.com/user-attachments/assets/639d845c-d145-4731-8555-7b46d0d15fee)


- 不正なデータ(必須項目を満たしていない)を登録したときに例外が発生する(400)
![登録　不正なデータ](https://github.com/user-attachments/assets/698c7dea-0b11-43d4-8e9b-03529d0d0826)

Update処理

- 存在するIDを指定したときにそのレコードを更新できること(200)
![更新　存在するID](https://github.com/user-attachments/assets/957b4c68-c62f-42ae-b90e-355858ef9b34)

- 存在しないIDを指定したときに例外が発生し更新できないこと(404)
![更新　ID　例外](https://github.com/user-attachments/assets/7a8ecfdc-30d1-4573-b1ab-e14a46cc3ce0)

- 不正なデータを更新したときに例外が発生すること(400)
![更新　不正なデータ](https://github.com/user-attachments/assets/cd45c7a2-09cb-4f27-ab3a-f414592760e5)

Delete処理

- 存在するIDを指定したときにそのレコードを削除できること(200)
![スクリーンショット 2024-08-20 171920](https://github.com/user-attachments/assets/599c94fc-dfb8-4e80-80cf-4d90bb05ca72)

- 存在しないIDを指定したときに例外が発生し削除できないこと(404)
![スクリーンショット 2024-08-20 171956](https://github.com/user-attachments/assets/d0537277-99dd-447a-9c40-c43b152bc538)
