### PR TITLE
テスト実行をするワークフローを追加

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -14,16 +14,18 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-    - name: Build with Gradle Wrapper
-      run: ./gradlew build
-      
+      - name: Setup DB
+        run: docker compose up -d
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -32,3 +32,9 @@ jobs:
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build
+
+      - name: Notify Discord
+        uses: sarisia/actions-status-discord@v1
+        if: always()
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,0 +1,29 @@
+name: Run Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    - name: Build with Gradle Wrapper
+      run: ./gradlew build
+      

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -21,6 +21,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
       - name: Setup DB
         run: docker compose up -d
 

--- a/src/test/java/com/example/deskworkoutservice/integrationtest/DeskworkoutRestApiIntegrationTest.java
+++ b/src/test/java/com/example/deskworkoutservice/integrationtest/DeskworkoutRestApiIntegrationTest.java
@@ -163,7 +163,7 @@ public class DeskworkoutRestApiIntegrationTest {
     @DataSet(value = "datasets/deskworkouts.yml")
     @Transactional
     void 存在するIDを指定したときにそのレコードを取得できること() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts/2"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts/3"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""
                         {

--- a/src/test/java/com/example/deskworkoutservice/integrationtest/DeskworkoutRestApiIntegrationTest.java
+++ b/src/test/java/com/example/deskworkoutservice/integrationtest/DeskworkoutRestApiIntegrationTest.java
@@ -163,7 +163,7 @@ public class DeskworkoutRestApiIntegrationTest {
     @DataSet(value = "datasets/deskworkouts.yml")
     @Transactional
     void 存在するIDを指定したときにそのレコードを取得できること() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts/3"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts/2"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""
                         {

--- a/src/test/java/com/example/deskworkoutservice/integrationtest/DeskworkoutRestApiIntegrationTest.java
+++ b/src/test/java/com/example/deskworkoutservice/integrationtest/DeskworkoutRestApiIntegrationTest.java
@@ -29,7 +29,7 @@ public class DeskworkoutRestApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/deskworkouts.yml")
     @Transactional
-    void null又は空のクエリ文字列を渡したときに全件取得できること() throws Exception {
+    void nullのクエリ文字列を渡したときに全件取得できること() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""
@@ -76,6 +76,58 @@ public class DeskworkoutRestApiIntegrationTest {
                             }
                         ]
                         """, true));
+    }
+
+    @Test
+    @DataSet(value = "datasets/deskworkouts.yml")
+    @Transactional
+    void 空のクエリ文字列を渡したときに全件取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/deskworkouts"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                            {
+                                "id": 1,
+                                "name": "シットアップ",
+                                "howto": "直角に曲げた膝を机裏にタッチする",
+                                "repetition": 10,
+                                "bodyParts": "お腹",
+                                "difficulty": "初級"
+                            },
+                            {
+                                "id": 2,
+                                "name": "バックエクステンション",
+                                "howto": "お尻を背もたれに付けたまま、デコルテを机に近づける",
+                                "repetition": 10,
+                                "bodyParts": "背中",
+                                "difficulty": "中級"
+                            },
+                            {
+                                "id": 3,
+                                "name": "ショルダーダウン",
+                                "howto": "肘で背もたれを押したまま、肩を引き下げる",
+                                "repetition": 1,
+                                "bodyParts": "肩",
+                                "difficulty": "初級"
+                            },
+                            {
+                                "id": 4,
+                                "name": "ニーエクステンション",
+                                "howto": "内ももをくっ付けたまま、膝を伸ばす",
+                                "repetition": 10,
+                                "bodyParts": "脚",
+                                "difficulty": "初級"
+                            },
+                            {
+                                "id": 5,
+                                "name": "スクワット",
+                                "howto": "片膝を斜め横に向けたまま、お尻を椅子から持ち上げる",
+                                "repetition": 10,
+                                "bodyParts": "お尻",
+                                "difficulty": "上級"
+                            }
+                        ]
+                        """));
     }
 
     @Test


### PR DESCRIPTION
# 最終課題

「デスクでできる筋トレメニュー」を管理するアプリケーションをCRUD処理を用いて開発します。

## 概要

今回はGithub Actionsを用いて、テスト実行とDiscoed通知のワークフローを導入しました。

## 動作確認

下記確認済みです。
- テストが失敗したとき期待通りのメッセージがDiscoedへ通知されること
![スクリーンショット 2024-08-26 115346](https://github.com/user-attachments/assets/3ef18d42-e837-4fcd-ab0c-91cb3ca5ee63)


- テストが成功したとき期待通りのメッセージがDiscordへ通知されること
![スクリーンショット 2024-08-26 114302](https://github.com/user-attachments/assets/bd1536a8-9761-42c4-83ea-2d9f25ac8baf)
